### PR TITLE
Dockerfile: Set default database driver and source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN apt-get -y install zip libsqlite3-dev sqlite3 1> /dev/null 2> /dev/null
 RUN make docker deps build embed install
 
 EXPOSE 80
+ENV DRONE_DATABASE_DATASOURCE /var/lib/drone/drone.sqlite
+ENV DRONE_DATABASE_DRIVER sqlite3
 VOLUME ["/var/lib/drone"]
 ENTRYPOINT ["/usr/local/bin/droned"]


### PR DESCRIPTION
This will allow a default install to make use of the /var/lib/drone volume without having to set this manually.